### PR TITLE
add detector from using Classical.choice

### DIFF
--- a/Katydid.lean
+++ b/Katydid.lean
@@ -1,3 +1,4 @@
+import Katydid.Std.Linter.DetectClassical
 import Katydid.Std.BEq
 import Katydid.Std.Ordering
 import Katydid.Std.Decidable

--- a/Katydid/Regex/IndexedRegex.lean
+++ b/Katydid/Regex/IndexedRegex.lean
@@ -1,3 +1,4 @@
+import Katydid.Std.Linter.DetectClassical
 import Katydid.Std.Decidable
 
 import Katydid.Regex.Language

--- a/Katydid/Regex/Language.lean
+++ b/Katydid/Regex/Language.lean
@@ -1,3 +1,4 @@
+import Katydid.Std.Linter.DetectClassical
 import Katydid.Std.Lists
 
 namespace Language

--- a/Katydid/Regex/SimpleRegex.lean
+++ b/Katydid/Regex/SimpleRegex.lean
@@ -3,6 +3,7 @@ import Lean
 import Mathlib.Tactic.SplitIfs
 import Mathlib.Tactic.CongrM
 
+import Katydid.Std.Linter.DetectClassical
 import Katydid.Std.Decidable
 
 import Katydid.Regex.Language

--- a/Katydid/Regex/SmartRegex.lean
+++ b/Katydid/Regex/SmartRegex.lean
@@ -1,3 +1,4 @@
+import Katydid.Std.Linter.DetectClassical
 import Katydid.Std.NonEmptyList
 
 import Katydid.Regex.Language

--- a/Katydid/Std/BEq.lean
+++ b/Katydid/Std/BEq.lean
@@ -1,3 +1,5 @@
+import Katydid.Std.Linter.DetectClassical
+
 theorem beq_eq_or_neq {α: Type} [BEq α] (x y: α):
   BEq.beq x y \/ (Not (BEq.beq x y)) := by
   by_cases BEq.beq x y

--- a/Katydid/Std/Decidable.lean
+++ b/Katydid/Std/Decidable.lean
@@ -1,3 +1,5 @@
+import Katydid.Std.Linter.DetectClassical
+
 namespace Decidable
 
 def or {α β: Prop} (a: Decidable α) (b: Decidable β): Decidable (α \/ β) :=

--- a/Katydid/Std/Linter/DetectClassical.lean
+++ b/Katydid/Std/Linter/DetectClassical.lean
@@ -1,0 +1,67 @@
+-- Thank you to Damiano Testa
+-- https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/restricting.20axioms/near/501743343
+
+import Lean.Util.CollectAxioms
+import Mathlib.Tactic.DeclarationNames
+
+/-!
+#  The "detectClassical" linter
+
+The "detectClassical" linter emits a warning on declarations that depend on the `Classical.choice`
+axiom.
+-/
+
+open Lean Elab Command
+
+namespace Katydid.Std.Linter
+
+/--
+The "detectClassical" linter emits a warning on declarations that depend on the `Classical.choice`
+axiom.
+-/
+register_option linter.detectClassical : Bool := {
+  defValue := true
+  descr := "enable the detectClassical linter"
+}
+
+/--
+The `linter.verbose.detectClassical` option is a flag to make the `detectClassical` linter emit
+a confirmation on declarations that depend *not* on the `Classical.choice` axiom.
+-/
+register_option linter.verbose.detectClassical : Bool := {
+  defValue := false
+  descr := "enable the verbose setting for the detectClassical linter"
+}
+
+namespace DetectClassical
+
+@[inherit_doc Katydid.Std.Linter.linter.detectClassical]
+def detectClassicalLinter : Linter where run := withSetOptionIn fun stx ↦ do
+  unless Linter.getLinterValue linter.detectClassical (← getOptions) do
+    return
+  if (← get).messages.hasErrors then
+    return
+  let d := (stx.getPos?.getD default)
+  let nmsd := (← Mathlib.Linter.getNamesFrom d)
+  let nms := nmsd.filter (! ·.getId.isInternal)
+  let verbose? := Linter.getLinterValue linter.verbose.detectClassical (← getOptions)
+  for constStx in nms do
+    let constName := constStx.getId
+    let axioms ← collectAxioms constName
+    if axioms.isEmpty then
+      if verbose? then
+        logInfoAt constStx m!"'{constName}' does not depend on any axioms"
+      return
+    if !axioms.contains `Classical.choice then
+      if verbose? then
+        logInfoAt constStx
+          m!"'{constName}' is non-classical and depends on axioms: {axioms.toList}"
+    else
+      Linter.logLint linter.detectClassical constStx
+        m!"'{constName}' depends on 'Classical.choice' on axioms: {axioms.toList}"
+
+initialize addLinter detectClassicalLinter
+
+end DetectClassical
+
+end Katydid.Std.Linter

--- a/Katydid/Std/Lists.lean
+++ b/Katydid/Std/Lists.lean
@@ -6,6 +6,7 @@
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.SplitIfs
 
+import Katydid.Std.Linter.DetectClassical
 import Katydid.Std.BEq
 import Katydid.Std.Ordering
 import Katydid.Std.Nat

--- a/Katydid/Std/NonEmptyList.lean
+++ b/Katydid/Std/NonEmptyList.lean
@@ -1,3 +1,4 @@
+import Katydid.Std.Linter.DetectClassical
 import Katydid.Std.Ordering
 import Katydid.Std.Lists
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -3,8 +3,17 @@ open Lake DSL
 
 package katydid
 
+abbrev packageLinters : Array LeanOption := #[
+  ⟨`weak.linter.detectClassical, true⟩
+]
+
+abbrev packageLeanOptions :=
+  packageLinters
+
 @[default_target]
-lean_lib Katydid
+lean_lib Katydid where
+  leanOptions := packageLeanOptions
+  moreServerOptions := packageLinters
 
 -- dependencies std4, quote4 are obtained transitively through mathlib4
 require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.14.0"


### PR DESCRIPTION
Seems Classical.choice is used quite a bit more than I would have thought:

```
% lake build
⚠ [679/690] Replayed Katydid.Std.Lists
warning: ././././Katydid/Std/Lists.lean:50:4: 'Lists.mergeReps' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Std/Lists.lean:442:8: 'list_take_take' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Std/Lists.lean:653:8: 'list_take_length' depends on 'Classical.choice' on axioms: [propext, Classical.choice, Quot.sound]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Std/Lists.lean:767:8: 'list_prefix_leq_length' depends on 'Classical.choice' on axioms: [propext, Classical.choice, Quot.sound]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Std/Lists.lean:791:8: 'list_drop_app' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Std/Lists.lean:803:8: 'list_drop_app'' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Std/Lists.lean:825:8: 'list_prefix_length_leq' depends on 'Classical.choice' on axioms: [propext, Classical.choice, Quot.sound]
note: this linter can be disabled with `set_option linter.detectClassical false`
⚠ [681/690] Replayed Katydid.Std.Balistic
warning: ././././Katydid/Std/Balistic.lean:483:0: declaration uses 'sorry'
warning: ././././Katydid/Std/Balistic.lean:503:0: declaration uses 'sorry'
warning: ././././Katydid/Std/Balistic.lean:508:0: declaration uses 'sorry'
⚠ [682/690] Replayed Katydid.Std.NonEmptyList
warning: ././././Katydid/Std/NonEmptyList.lean:49:4: 'NonEmptyList.eraseReps' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Std/NonEmptyList.lean:59:4: 'NonEmptyList.mergeReps' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
⚠ [684/690] Replayed Katydid.Regex.Language
warning: ././././Katydid/Regex/Language.lean:735:8: 'Language.simp_not_not_is_double_negation' depends on 'Classical.choice' on axioms: [Quot.sound,
 propext,
 Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/Language.lean:740:8: 'Language.simp_not_and_demorgen' depends on 'Classical.choice' on axioms: [Quot.sound, propext, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
ℹ [685/690] Replayed Katydid.Regex.SimpleRegex
info: ././././Katydid/Regex/SimpleRegex.lean:275:0: 'SimpleRegex.decidableDenote' depends on axioms: [propext, Quot.sound]
⚠ [686/690] Replayed Katydid.Regex.IndexedRegex
warning: ././././Katydid/Regex/IndexedRegex.lean:46:4: declaration uses 'sorry'
warning: ././././Katydid/Regex/IndexedRegex.lean:50:4: declaration uses 'sorry'
warning: ././././Katydid/Regex/IndexedRegex.lean:50:4: declaration uses 'sorry'
warning: ././././Katydid/Regex/IndexedRegex.lean:50:4: declaration uses 'sorry'
⚠ [687/690] Replayed Katydid.Regex.SmartRegex
warning: ././././Katydid/Regex/SmartRegex.lean:316:4: 'SmartRegex.orFromList' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:343:8: 'SmartRegex.orToList_is_orFromList' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:388:4: 'SmartRegex.smartOr' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:426:16: declaration uses 'sorry'
warning: ././././Katydid/Regex/SmartRegex.lean:443:8: declaration uses 'sorry'
warning: ././././Katydid/Regex/SmartRegex.lean:443:8: 'SmartRegex.smartOr_is_or' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice, sorryAx]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:505:4: 'SmartRegex.derive' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:519:8: 'SmartRegex.derive_commutes' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice, sorryAx]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:610:4: 'SmartRegex.derives' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:614:8: 'SmartRegex.derives_commutes' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice, sorryAx]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:632:4: 'SmartRegex.validate' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:636:8: 'SmartRegex.validate_commutes' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice, sorryAx]
note: this linter can be disabled with `set_option linter.detectClassical false`
warning: ././././Katydid/Regex/SmartRegex.lean:645:4: 'SmartRegex.decidableDenote' depends on 'Classical.choice' on axioms: [propext, Quot.sound, Classical.choice, sorryAx]
note: this linter can be disabled with `set_option linter.detectClassical false`
⚠ [688/690] Replayed Katydid.Expr.Desc
warning: ././././Katydid/Expr/Desc.lean:154:4: declaration uses 'sorry'
warning: ././././Katydid/Expr/Desc.lean:166:4: declaration uses 'sorry'
warning: ././././Katydid/Expr/Desc.lean:178:4: declaration uses 'sorry'
warning: ././././Katydid/Expr/Desc.lean:227:8: declaration uses 'sorry'
Build completed successfully.
```

Good detections include:
`Language.simp_not_not_is_double_negation`

Some surprises of using Classical.choice include:
```
def orFromList (xs: NonEmptyList (Regex α)): Regex α :=
  match xs with
  | NonEmptyList.mk x1 [] =>
    x1
  | NonEmptyList.mk x1 (x2::xs) =>
    Regex.or x1 (orFromList (NonEmptyList.mk x2 xs))
```

where NonEmptyList is defined as:
```
structure NonEmptyList (α: Type) where
  head : α
  tail : List α
```

So I am not sure how avoidable this is in the general in Lean