### PR TITLE
introduce the any operator for smart Regex

### DIFF
--- a/Katydid/Regex/Language.lean
+++ b/Katydid/Regex/Language.lean
@@ -163,6 +163,18 @@ theorem null_emptystr {α: Type}:
   @null α emptystr = True := by
   rw [null_iff_emptystr]
 
+theorem null_iff_any {α: Type}:
+  @null α any <-> False :=
+  Iff.intro nofun nofun
+
+theorem not_null_if_any {α: Type}:
+  @null α any -> False :=
+  nofun
+
+theorem null_any {α: Type}:
+  @null α any = False := by
+  rw [null_iff_any]
+
 theorem null_iff_char {α: Type} {c: α}:
   null (char c) <-> False :=
   Iff.intro nofun nofun


### PR DESCRIPTION
The `any` operator is necessary to be able to apply smart constructor rules for `(star any)`
An alternative would be to introduce the `not` operator and use `(not emptyset)` to represent `.*`, but this seemed simpler.